### PR TITLE
Use instance roles instead of explicit user creds

### DIFF
--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -47,15 +47,10 @@ DAYS_OF_DMARC_REPORTS = 1
 PAGE_SIZE = 100000  # Number of documents per query
 
 
-def update_bucket(bucket_name, local_file, remote_file_name,
-                  aws_access_key_id, aws_secret_access_key):
+def update_bucket(bucket_name, local_file, remote_file_name):
     '''update the s3 bucket with the new contents'''
 
-    s3 = boto3.client(
-        's3',
-        aws_access_key_id=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key
-    )
+    s3 = boto3.client('s3')
 
     s3.upload_file(local_file, bucket_name, remote_file_name)
 
@@ -306,11 +301,11 @@ def main():
                        assessment_collection[collection],
                        tbz_file, tbz_filename, end_of_data_collection)
 
-    json_data = util.to_json(get_dmarc_data(DMARC_AWS_ACCESS_KEY_ID,
-                                            DMARC_AWS_SECRET_ACCESS_KEY,
-                                            ES_REGION, ES_URL,
+    # Note that we use the elasticsearch AWS profile here
+    json_data = util.to_json(get_dmarc_data(ES_REGION, ES_URL,
                                             DAYS_OF_DMARC_REPORTS,
-                                            ES_RETRIEVE_SIZE))
+                                            ES_RETRIEVE_SIZE,
+                                            "elasticsearch"))
     json_filename = '{!s}_{!s}.json'.format('DMARC',
                                             end_of_data_collection.isoformat().replace(':', '').split('.')[0])
     dmarc_file = open(json_filename, 'w')
@@ -336,8 +331,7 @@ def main():
 
     if args['--aws']:
         # send the contents to the s3 bucket
-        update_bucket(BUCKET_NAME, gpg_full_path_filename, gpg_file_name,
-                      AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
+        update_bucket(BUCKET_NAME, gpg_full_path_filename, gpg_file_name)
         print('Upload to AWS bucket complete')
     print('Encrypted, signed, compressed JSON data written to file: {!s}'.format(gpg_full_path_filename))
 

--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-'''Create compressed, encrypted, signed extract file with Federal CyHy data for integration with the Weathermap project.
+'''Create compressed, encrypted, signed extract file with Federal CyHy
+data for integration with the Weathermap project.
 
 Usage:
   COMMAND_NAME [--cyhy_section CYHY_SECTION] [--scan_section SCAN_SECTION] [--assessment_section ASSESSMENT_SECTION] [-v | --verbose] [-f | --federal] [-a | --aws] --config CONFIG_FILE [--date DATE]
@@ -20,22 +21,16 @@ Options:
 
 '''
 
-import datetime
-import json
-import logging
 import re
 import sys
 from ConfigParser import SafeConfigParser
-from datetime import datetime, timedelta
+from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from docopt import docopt
-from requests_aws4auth import AWS4Auth
 import boto3
-import cStringIO
 import gnupg    # pip install python-gnupg
 import os
 from pytz import timezone
-import requests
 import subprocess
 import tarfile
 import time
@@ -49,9 +44,11 @@ HEADER = ''
 MAX_ENTRIES = 10
 DEFAULT_ES_RETRIEVE_SIZE = 10000
 DAYS_OF_DMARC_REPORTS = 1
-PAGE_SIZE = 100000 # Number of documents per query
+PAGE_SIZE = 100000  # Number of documents per query
 
-def update_bucket(bucket_name, local_file, remote_file_name, aws_access_key_id, aws_secret_access_key):
+
+def update_bucket(bucket_name, local_file, remote_file_name,
+                  aws_access_key_id, aws_secret_access_key):
     '''update the s3 bucket with the new contents'''
 
     s3 = boto3.client(
@@ -65,24 +62,32 @@ def update_bucket(bucket_name, local_file, remote_file_name, aws_access_key_id, 
 
 def create_dummy_files(output_dir):
     ''' Used for testing cleanup routine below '''
-    for n in range(1,21):
+    for n in range(1, 21):
         dummy_filename = 'dummy_file_{!s}.gpg'.format(n)
         full_path_dummy_filename = os.path.join(output_dir, dummy_filename)
         subprocess.call(['touch', full_path_dummy_filename])
         st = os.stat(full_path_dummy_filename)
-        # Set file modification time to n days earlier than it was
-        os.utime(full_path_dummy_filename, (st.st_atime, st.st_mtime - (86400 * n)))        # 86400 seconds per day
+        # Set file modification time to n days earlier than it was.
+        # Note that there are 86400 seconds per day.
+        os.utime(full_path_dummy_filename,
+                 (st.st_atime, st.st_mtime - (86400 * n)))
 
 
 def cleanup_old_files(output_dir, file_retention_num_days):
-    ''' Deletes *.gpg files older than file_retention_num_days in the specified output_dir'''
+    '''Deletes *.gpg files older than file_retention_num_days in the
+specified output_dir'''
     now_unix = time.time()
     for filename in os.listdir(output_dir):
-        if re.search('.gpg$', filename):        # We only care about filenames that end with .gpg
+        # We only care about filenames that end with .gpg
+        if re.search('.gpg$', filename):
             full_path_filename = os.path.join(output_dir, filename)
-            # If file modification time is older than file_retention_num_days
-            if os.stat(full_path_filename).st_mtime < now_unix - (file_retention_num_days * 86400):     # 86400 seconds per day
-                os.remove(full_path_filename)   # Delete file locally
+            # If file modification time is older than
+            # file_retention_num_days.  Note that there are 86400
+            # seconds per day.
+            file_retention_in_secs = file_retention_num_days * 86400
+            if os.stat(full_path_filename).st_mtime < now_unix - file_retention_in_secs:
+                # Delete file locally
+                os.remove(full_path_filename)
 
 
 # TODO Finish function to delete files until there is only X in the bucket
@@ -99,20 +104,30 @@ def cleanup_bucket_files(aws_access_key_id, aws_secret_access_key):
             print(key)
             print(key['LastModified'])
 
-def query_data(collection, query, tbz_file, tbz_filename, end_of_data_collection):
+
+def query_data(collection, query, tbz_file, tbz_filename,
+               end_of_data_collection):
     print('Fetching from', collection.name, 'collection...')
-    json_filename = '{!s}_{!s}.json'.format(collection.name, end_of_data_collection.isoformat().replace(':','').split('.')[0])
-    collection_file = open(json_filename,'w')
-    skips = 0 # How many documents in to a query that will be skipped
-    count = collection.find(query, {'key':False}).count() # Number of documents in a query
+    json_filename = '{!s}_{!s}.json'.format(collection.name,
+                                            end_of_data_collection.isoformat().replace(':', '').split('.')[0])
+    collection_file = open(json_filename, 'w')
+    # How many documents into a query that will be skipped
+    skips = 0
+    # Number of documents in a query
+    count = collection.find(query, {'key': False}).count()
     while skips < count:
-        collection_file.write(util.to_json(list(collection.find(query, {'key':False}).skip(skips).limit(PAGE_SIZE)))) # Pull documents between n and n + 100000
+        # Pull documents between n and n + 100000
+        collection_file.write(util.to_json(list(collection.find(query, {'key': False}).skip(skips).limit(PAGE_SIZE))))
         skips += PAGE_SIZE
     collection_file.close()
     if count > PAGE_SIZE:
-        # The first sed removes the ][ created by chunking the queries then the 2nd sed adds , to the document at the end of a chunked list
-        os.system('sed -i "/\]\[/d" %s ; sed -i "s/\}$/\}\,/g" %s ; ' % (json_filename, json_filename)) # If on MAC you will need gsed and gawk
-        # The previous sed will leave a }, at the last document in the list which is removed with this aws_access_key_id
+        # The first sed removes the ][ created by chunking the queries
+        # then the 2nd sed adds , to the document at the end of a
+        # chunked list
+        # If on MAC you will need gsed and gawk.
+        os.system('sed -i "/\]\[/d" %s ; sed -i "s/\}$/\}\,/g" %s ; ' % (json_filename, json_filename))
+        # The previous sed will leave a }, at the last document in the
+        # list which is removed with this aws_access_key_id
         os.system('''awk 'NR==FNR{tgt=NR-1;next} (FNR==tgt) && /\},/ { $1="    }" } 1' %s %s > %s.bak''' % (json_filename, json_filename, json_filename))
         # This is a workaround for inplace
         os.system('mv %s.bak %s' % (json_filename, json_filename))
@@ -136,7 +151,6 @@ def main():
     if args['--assessment_section']:
         assessment_db = database.db_from_config(args['--assessment_section'])
     now = util.utcnow()
-    now_unix = time.time()
     # import IPython; IPython.embed() #<<< BREAKPOINT >>>
     # sys.exit(0)
 
@@ -151,7 +165,9 @@ def main():
     SIGNER = config.get('DEFAULT', 'SIGNER')
     SIGNER_PASSPHRASE = config.get('DEFAULT', 'SIGNER_PASSPHRASE')
     OUTPUT_DIR = config.get('DEFAULT', 'OUTPUT_DIR')
-    FILE_RETENTION_NUM_DAYS = int(config.get('DEFAULT', 'FILE_RETENTION_NUM_DAYS'))  # Files older than this are deleted by cleanup_old_files()
+    # Files older than this are deleted by cleanup_old_files()
+    FILE_RETENTION_NUM_DAYS = int(config.get('DEFAULT',
+                                             'FILE_RETENTION_NUM_DAYS'))
     AWS_ACCESS_KEY_ID = config.get('DEFAULT', 'AWS_ACCESS_KEY_ID')
     AWS_SECRET_ACCESS_KEY = config.get('DEFAULT', 'AWS_SECRET_ACCESS_KEY')
     DMARC_AWS_ACCESS_KEY_ID = config.get('DMARC', 'AWS_ACCESS_KEY_ID')
@@ -166,7 +182,14 @@ def main():
         sys.exit(1)
 
     # Set up GPG (used for encrypting and signing)
-    gpg = gnupg.GPG(gpgbinary='gpg2', gnupghome=GNUPG_HOME, verbose=args['--verbose'], options=['--pinentry-mode', 'loopback', '-u', SIGNER])
+    gpg = gnupg.GPG(gpgbinary='gpg2', gnupghome=GNUPG_HOME,
+                    verbose=args['--verbose'],
+                    options=[
+                        '--pinentry-mode',
+                        'loopback',
+                        '-u',
+                        SIGNER
+                    ])
     gpg.encoding = 'utf-8'
 
     if args['--date']:
@@ -186,22 +209,82 @@ def main():
         orgs = list(set(all_orgs) - ORGS_EXCLUDED)
 
     # Create tar/bzip2 file for writing
-    tbz_filename = 'cyhy_extract_{!s}.tbz'.format(end_of_data_collection.isoformat().replace(':','').split('.')[0])
+    tbz_filename = 'cyhy_extract_{!s}.tbz'.format(end_of_data_collection.isoformat().replace(':', '').split('.')[0])
     tbz_file = tarfile.open(tbz_filename, mode='w:bz2')
 
     cyhy_collection = {
-        'host_scans': {'owner':{'$in':orgs}, 'time':{'$gte':start_of_data_collection, '$lt':end_of_data_collection}},
-        'port_scans': {'owner':{'$in':orgs}, 'time':{'$gte':start_of_data_collection, '$lt':end_of_data_collection}},
-        'vuln_scans': {'owner':{'$in':orgs}, 'time':{'$gte':start_of_data_collection, '$lt':end_of_data_collection}},
-        'hosts': {'owner':{'$in':orgs}, 'last_change':{'$gte':start_of_data_collection, '$lt':end_of_data_collection}},
-        'tickets': {'owner':{'$in':orgs}, 'last_change':{'$gte':start_of_data_collection, '$lt':end_of_data_collection}}
+        'host_scans': {
+            'owner': {
+                '$in': orgs
+            },
+            'time': {
+                '$gte': start_of_data_collection,
+                '$lt': end_of_data_collection
+            }
+        },
+        'port_scans': {
+            'owner': {
+                '$in': orgs
+            },
+            'time': {
+                '$gte': start_of_data_collection,
+                '$lt': end_of_data_collection
+            }
+        },
+        'vuln_scans': {
+            'owner': {
+                '$in': orgs
+            },
+            'time': {
+                '$gte': start_of_data_collection,
+                '$lt': end_of_data_collection
+            }
+        },
+        'hosts': {
+            'owner': {
+                '$in': orgs
+            },
+            'last_change': {
+                '$gte': start_of_data_collection,
+                '$lt': end_of_data_collection
+            }
+        },
+        'tickets': {
+            'owner': {
+                '$in': orgs
+            },
+            'last_change': {
+                '$gte': start_of_data_collection,
+                '$lt': end_of_data_collection
+            }
+        }
     }
 
     scan_collection = {
-        'https_scan': {'scan_date':{'$gte':start_of_data_collection, '$lt':end_of_data_collection}},
-        'sslyze_scan': {'scan_date':{'$gte':start_of_data_collection, '$lt':end_of_data_collection}},
-        'trustymail': {'scan_date':{'$gte':start_of_data_collection, '$lt':end_of_data_collection}},
-        'certs': {'sct_or_not_before':{'$gte':start_of_data_collection, '$lt':end_of_data_collection}}
+        'https_scan': {
+            'scan_date': {
+                '$gte': start_of_data_collection,
+                '$lt': end_of_data_collection
+            }
+        },
+        'sslyze_scan': {
+            'scan_date': {
+                '$gte': start_of_data_collection,
+                '$lt': end_of_data_collection
+            }
+        },
+        'trustymail': {
+            'scan_date': {
+                '$gte': start_of_data_collection,
+                '$lt': end_of_data_collection
+            }
+        },
+        'certs': {
+            'sct_or_not_before': {
+                '$gte': start_of_data_collection,
+                '$lt': end_of_data_collection
+            }
+        }
     }
 
     assessment_collection = {
@@ -211,18 +294,26 @@ def main():
 
     if args['--cyhy_section']:
         for collection in cyhy_collection:
-            query_data(cyhy_db[collection], cyhy_collection[collection], tbz_file, tbz_filename, end_of_data_collection)
+            query_data(cyhy_db[collection], cyhy_collection[collection],
+                       tbz_file, tbz_filename, end_of_data_collection)
     if args['--scan_section']:
         for collection in scan_collection:
-            query_data(scan_db[collection], scan_collection[collection], tbz_file, tbz_filename, end_of_data_collection)
+            query_data(scan_db[collection], scan_collection[collection],
+                       tbz_file, tbz_filename, end_of_data_collection)
     if args['--assessment_section']:
         for collection in assessment_collection:
-            query_data(assessment_db[collection], assessment_collection[collection], tbz_file, tbz_filename, end_of_data_collection)
+            query_data(assessment_db[collection],
+                       assessment_collection[collection],
+                       tbz_file, tbz_filename, end_of_data_collection)
 
-    json_data = util.to_json(get_dmarc_data(DMARC_AWS_ACCESS_KEY_ID, DMARC_AWS_SECRET_ACCESS_KEY,
-                                    ES_REGION, ES_URL, DAYS_OF_DMARC_REPORTS, ES_RETRIEVE_SIZE))
-    json_filename = '{!s}_{!s}.json'.format('DMARC', end_of_data_collection.isoformat().replace(':','').split('.')[0])
-    dmarc_file = open(json_filename,'w')
+    json_data = util.to_json(get_dmarc_data(DMARC_AWS_ACCESS_KEY_ID,
+                                            DMARC_AWS_SECRET_ACCESS_KEY,
+                                            ES_REGION, ES_URL,
+                                            DAYS_OF_DMARC_REPORTS,
+                                            ES_RETRIEVE_SIZE))
+    json_filename = '{!s}_{!s}.json'.format('DMARC',
+                                            end_of_data_collection.isoformat().replace(':', '').split('.')[0])
+    dmarc_file = open(json_filename, 'w')
     dmarc_file.write(json_data)
     tbz_file.add(json_filename)
     tbz_file.close()
@@ -232,9 +323,12 @@ def main():
 
     gpg_file_name = tbz_filename + '.gpg'
     gpg_full_path_filename = os.path.join(OUTPUT_DIR, gpg_file_name)
-    # Encrypt (with public keys for all RECIPIENTS) & sign (with SIGNER's private key)
+    # Encrypt (with public keys for all RECIPIENTS) and sign (with
+    # SIGNER's private key)
     with open(tbz_filename, 'rb') as f:
-        status = gpg.encrypt_file(f, RECIPIENTS, armor=False, sign=SIGNER, passphrase=SIGNER_PASSPHRASE, output=gpg_full_path_filename)
+        status = gpg.encrypt_file(f, RECIPIENTS, armor=False, sign=SIGNER,
+                                  passphrase=SIGNER_PASSPHRASE,
+                                  output=gpg_full_path_filename)
 
     if not status.ok:
         print('\nFAILURE - GPG ERROR!\n GPG status: {!s} \n GPG stderr:\n{!s}'.format(status.status, status.stderr))
@@ -242,7 +336,8 @@ def main():
 
     if args['--aws']:
         # send the contents to the s3 bucket
-        update_bucket(BUCKET_NAME, gpg_full_path_filename, gpg_file_name, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
+        update_bucket(BUCKET_NAME, gpg_full_path_filename, gpg_file_name,
+                      AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
         print('Upload to AWS bucket complete')
     print('Encrypted, signed, compressed JSON data written to file: {!s}'.format(gpg_full_path_filename))
 
@@ -254,5 +349,6 @@ def main():
 
     print('\nSUCCESS!')
 
-if __name__=='__main__':
+
+if __name__ == '__main__':
     main()

--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -163,13 +163,11 @@ def main():
     # Files older than this are deleted by cleanup_old_files()
     FILE_RETENTION_NUM_DAYS = int(config.get('DEFAULT',
                                              'FILE_RETENTION_NUM_DAYS'))
-    AWS_ACCESS_KEY_ID = config.get('DEFAULT', 'AWS_ACCESS_KEY_ID')
-    AWS_SECRET_ACCESS_KEY = config.get('DEFAULT', 'AWS_SECRET_ACCESS_KEY')
-    DMARC_AWS_ACCESS_KEY_ID = config.get('DMARC', 'AWS_ACCESS_KEY_ID')
-    DMARC_AWS_SECRET_ACCESS_KEY = config.get('DMARC', 'AWS_SECRET_ACCESS_KEY')
     ES_REGION = config.get('DMARC', 'ES_REGION')
     ES_URL = config.get('DMARC', 'ES_URL')
     ES_RETRIEVE_SIZE = config.get('DMARC', 'ES_RETRIEVE_SIZE')
+    ES_AWS_CONFIG_SECTION_NAME = config.get('DMARC',
+                                            'ES_AWS_CONFIG_SECTION_NAME')
 
     # Check if OUTPUT_DIR exists; if not, bail out
     if not os.path.exists(OUTPUT_DIR):
@@ -305,7 +303,7 @@ def main():
     json_data = util.to_json(get_dmarc_data(ES_REGION, ES_URL,
                                             DAYS_OF_DMARC_REPORTS,
                                             ES_RETRIEVE_SIZE,
-                                            "elasticsearch"))
+                                            ES_AWS_CONFIG_SECTION_NAME))
     json_filename = '{!s}_{!s}.json'.format('DMARC',
                                             end_of_data_collection.isoformat().replace(':', '').split('.')[0])
     dmarc_file = open(json_filename, 'w')

--- a/aws_jobs/dmarc.py
+++ b/aws_jobs/dmarc.py
@@ -46,7 +46,7 @@ def query_elasticsearch(session, es_region, es_url, since,
     by Elasticsearch.
     """
     ans = None
-    
+
     # Construct the auth from the AWS credentials
     aws_credentials = session.get_credentials()
     awsauth = AWS4Auth(aws_credentials.access_key,
@@ -123,22 +123,15 @@ def query_elasticsearch(session, es_region, es_url, since,
 
     return ans
 
-def get_dmarc_data(aws_access_key_id, aws_secret_access_key,
-                   es_region, es_url, days,
-                   es_retrieve_size=DEFAULT_ES_RETRIEVE_SIZE):
+
+def get_dmarc_data(es_region, es_url, days,
+                   es_retrieve_size=DEFAULT_ES_RETRIEVE_SIZE,
+                   aws_profile="default"):
     """Query Elasticsearch for all DMARC aggregate reports received
     since a given time.
 
     Parameters
     ----------
-    aws_access_key_id : str
-    The AWS access key ID to use when connecting to the Elasticsearch
-    database.
-
-    aws_secret_access_key : str
-    The AWS secret access key to use when connecting to the
-    Elasticsearch database.
-
     es_region : str
     The AWS region in which the DMARC Elasticsearch database resides.
 
@@ -151,6 +144,9 @@ def get_dmarc_data(aws_access_key_id, aws_secret_access_key,
 
     es_retrieve_size : int
     The number of records to retrieve from Elasticsearch per request.
+
+    aws_profile : str
+    The name of the AWS profile to use.
 
     Returns
     -------
@@ -165,8 +161,7 @@ def get_dmarc_data(aws_access_key_id, aws_secret_access_key,
     since = datetime.utcnow() - timedelta(days=days)
 
     logging.info('Creating AWS session')
-    session = boto3.Session(aws_access_key_id=aws_access_key_id,
-                            aws_secret_access_key=aws_secret_access_key)
+    session = boto3.Session(profile=aws_profile)
 
     logging.info('Retrieving DMARC data')
     reports = query_elasticsearch(session, es_region, es_url, since,

--- a/aws_jobs/dmarc.py
+++ b/aws_jobs/dmarc.py
@@ -64,7 +64,7 @@ def query_elasticsearch(session, es_region, es_url, since,
                             {
                                 'range': {
                                     'report_metadata.date_range.begin': {
-                                        'gte': (since - datetime(1970,1,1)).total_seconds()
+                                        'gte': (since - datetime(1970, 1, 1)).total_seconds()
                                     }
                                 }
                             }

--- a/aws_jobs/dmarc.py
+++ b/aws_jobs/dmarc.py
@@ -161,7 +161,7 @@ def get_dmarc_data(es_region, es_url, days,
     since = datetime.utcnow() - timedelta(days=days)
 
     logging.info('Creating AWS session')
-    session = boto3.Session(profile=aws_profile)
+    session = boto3.Session(profile_name=aws_profile)
 
     logging.info('Retrieving DMARC data')
     reports = query_elasticsearch(session, es_region, es_url, since,


### PR DESCRIPTION
In this pull request I adapt the cyhy-feeds code to use instance roles instead of explicit user creds.  This pull request goes along with cisagov/cyhy_amis#184.

When reviewing, you will want to consider 4604b34 separately from the other changes.  In that particular commit I made a lot of whitespace changes to make the existing code more readable and to make flake8 happier.

Note also that in order to use this pull request you must add an entry `ES_AWS_CONFIG_SECTION_NAME = elasticsearch` to the `DMARC` section of the `cyhy-data-extract.cfg` config file.  Once this pull request is merged, the AWS access keys and AWS secret keys from that config can (and should) be removed.