### PR TITLE
Incomplete DMARC data

### DIFF
--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -308,6 +308,7 @@ def main():
                                             end_of_data_collection.isoformat().replace(':', '').split('.')[0])
     dmarc_file = open(json_filename, 'w')
     dmarc_file.write(json_data)
+    dmarc_file.close()
     tbz_file.add(json_filename)
     tbz_file.close()
     if os.path.exists(json_filename):

--- a/aws_jobs/dmarc.py
+++ b/aws_jobs/dmarc.py
@@ -1,6 +1,5 @@
 # standard python libraries
 from datetime import datetime, timedelta
-import json
 import logging
 import re
 
@@ -150,8 +149,8 @@ def get_dmarc_data(es_region, es_url, days,
 
     Returns
     -------
-    str : a string consisting of JSON data for all DMARC aggregate
-    reports received in specified time frame
+    dict : a dict consisting of data for all DMARC aggregate reports
+    received in the specified time frame
 
     Throws
     ------
@@ -167,5 +166,4 @@ def get_dmarc_data(es_region, es_url, days,
     reports = query_elasticsearch(session, es_region, es_url, since,
                                   es_retrieve_size)
 
-    # Convert objects to one big string
-    return json.dumps(reports)
+    return reports

--- a/aws_jobs/dmarc.py
+++ b/aws_jobs/dmarc.py
@@ -52,6 +52,8 @@ def query_elasticsearch(session, es_region, es_url, since,
                        aws_credentials.secret_key,
                        es_region, 'es',
                        session_token=aws_credentials.token)
+    # Compute since in seconds since the epoch
+    since_unix = (since - datetime(1970, 1, 1)).total_seconds()
     # Now construct the query.
     query = {
         'size': es_retrieve_size,
@@ -63,7 +65,7 @@ def query_elasticsearch(session, es_region, es_url, since,
                             {
                                 'range': {
                                     'report_metadata.date_range.begin': {
-                                        'gte': (since - datetime(1970, 1, 1)).total_seconds()
+                                        'gte': since_unix
                                     }
                                 }
                             }


### PR DESCRIPTION
@KyleEvers was seeing a bug where the JSON data in `json_filename` was incomplete.  This is due to the fact that the data contained in `json_filename` is read (via `tbz_file.add(json_filename)`) before `dmarc_file` is closed.  Therefore `dmarc_file`'s output buffer was not being flushed before the underlying file was being read.