### PR TITLE
Remove cyhy core dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 ._*
 *.egg-info
 .ipynb_checkpoints
+.python-version

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 ._*
 *.egg-info
 .ipynb_checkpoints
-.python_version

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 ._*
 *.egg-info
 .ipynb_checkpoints
+.python_version

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ pip install -r requirements.txt
 ### cyhy-data-extract Usage and Examples ###
 
 ```bash
-python2.7 cyhy-data-extract.py --cyhy_section cyhy_section --config cyhy-data-extract.cfg
-python2.7 cyhy-data-extract.py --scan_section scan_section --config cyhy-data-extract.cfg
-python2.7 cyhy-data-extract.py --assessment_section assessment_section --config cyhy-data-extract.cfg
-python2.7 cyhy-data-extract.py --cyhy_section cyhy_section --scan_section scan_section --config cyhy-data-extract.cfg
-python2.7 cyhy-data-extract.py --cyhy_section cyhy_section --scan_section scan_section --aws --config cyhy-data-extract.cfg
-python2.7 cyhy-data-extract.py --cyhy_section cyhy_section --scan_section scan_section --aws --config cyhy-data-extract.cfg --date 2019-01-25
-python2.7 cyhy-data-extract.py --cyhy_section cyhy_section --scan_section scan_section --assessment_section assessment_section --aws --config cyhy-data-extract.cfg --date 2019-01-25
+python2.7 cyhy-data-extract.py --cyhy_config cyhy_config --config cyhy-data-extract.cfg
+python2.7 cyhy-data-extract.py --scan_config scan_config --config cyhy-data-extract.cfg
+python2.7 cyhy-data-extract.py --assessment_config assessment_config --config cyhy-data-extract.cfg
+python2.7 cyhy-data-extract.py --cyhy_config cyhy_config --scan_config scan_config --config cyhy-data-extract.cfg
+python2.7 cyhy-data-extract.py --cyhy_config cyhy_config --scan_config scan_config --aws --config cyhy-data-extract.cfg
+python2.7 cyhy-data-extract.py --cyhy_config cyhy_config --scan_config scan_config --aws --config cyhy-data-extract.cfg --date 2019-01-25
+python2.7 cyhy-data-extract.py --cyhy_config cyhy_config --scan_config scan_config --assessment_config assessment_config --aws --config cyhy-data-extract.cfg --date 2019-01-25
 ```
 Note: The section names are taken from the cyhy.conf
 
@@ -45,18 +45,17 @@ Note: The section names are taken from the cyhy.conf
 Create compressed, encrypted, signed extract file with Federal CyHy data for integration with the Weathermap project.
 
 Usage:
-  COMMAND_NAME [--cyhy_section CYHY_SECTION] [--scan_section SCAN_SECTION] [--assessment_section ASSESSMENT_SECTION] [-v | --verbose] [-f | --federal] [-a | --aws] --config CONFIG_FILE [--date DATE]
+  COMMAND_NAME [--cyhy_config CYHY_config] [--scan_config SCAN_config] [--assessment_config ASSESSMENT_config] [-v | --verbose] [-a | --aws] --config CONFIG_FILE [--date DATE]
   COMMAND_NAME (-h | --help)
   COMMAND_NAME --version
 
 Options:
   -h --help                                                         Show this screen
   --version                                                         Show version
-  -x CYHY_SECTION --cyhy_section=CYHY_SECTION                       CyHy configuration section to use
-  -y SCAN_SECTION --scan_section=SCAN_SECTION                       Scan configuration section to use
-  -z ASSESSMENT_SECTION --assessment_section=ASSESSMENT_SECTION     Assessment configuration section to use
+  -x CYHY_CONFIG --cyhy_config=CYHY_CONFIG                       CyHy configuration section to use
+  -y SCAN_CONFIG --scan_config=SCAN_CONFIG                       Scan configuration section to use
+  -z ASSESSMENT_CONFIG --assessment_config=ASSESSMENT_CONFIG     Assessment configuration section to use
   -v --verbose                                                      Show verbose output
-  -f --federal                                                      Returns only Federal requestDocs
   -a --aws                                                          Output results to s3 bucket
   -c CONFIG_FILE --config=CONFIG_FILE                               Configuration file for this script
   -d DATE --date=DATE                                               Specific date to export data from in form: %Y-%m-%d (eg. 2018-12-31) NOTE that this date is in UTC

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ pip install -r requirements.txt
 ### cyhy-data-extract Usage and Examples ###
 
 ```bash
-python2.7 cyhy-data-extract.py --cyhy_config cyhy_config --config cyhy-data-extract.cfg
-python2.7 cyhy-data-extract.py --scan_config scan_config --config cyhy-data-extract.cfg
-python2.7 cyhy-data-extract.py --assessment_config assessment_config --config cyhy-data-extract.cfg
-python2.7 cyhy-data-extract.py --cyhy_config cyhy_config --scan_config scan_config --config cyhy-data-extract.cfg
-python2.7 cyhy-data-extract.py --cyhy_config cyhy_config --scan_config scan_config --aws --config cyhy-data-extract.cfg
-python2.7 cyhy-data-extract.py --cyhy_config cyhy_config --scan_config scan_config --aws --config cyhy-data-extract.cfg --date 2019-01-25
-python2.7 cyhy-data-extract.py --cyhy_config cyhy_config --scan_config scan_config --assessment_config assessment_config --aws --config cyhy-data-extract.cfg --date 2019-01-25
+python2.7 cyhy-data-extract.py --cyhy-config cyhy_config --config cyhy-data-extract.cfg
+python2.7 cyhy-data-extract.py --scan-config scan_config --config cyhy-data-extract.cfg
+python2.7 cyhy-data-extract.py --assessment-config assessment_config --config cyhy-data-extract.cfg
+python2.7 cyhy-data-extract.py --cyhy-config cyhy_config --scan-config scan_config --config cyhy-data-extract.cfg
+python2.7 cyhy-data-extract.py --cyhy-config cyhy_config --scan-config scan_config --aws --config cyhy-data-extract.cfg
+python2.7 cyhy-data-extract.py --cyhy-config cyhy_config --scan-config scan_config --aws --config cyhy-data-extract.cfg --date 2019-01-25
+python2.7 cyhy-data-extract.py --cyhy-config cyhy_config --scan-config scan_config --assessment-config assessment_config --aws --config cyhy-data-extract.cfg --date 2019-01-25
 ```
 Note: The section names are taken from the cyhy.conf
 
@@ -45,16 +45,16 @@ Note: The section names are taken from the cyhy.conf
 Create compressed, encrypted, signed extract file with Federal CyHy data for integration with the Weathermap project.
 
 Usage:
-  COMMAND_NAME [--cyhy_config CYHY_config] [--scan_config SCAN_config] [--assessment_config ASSESSMENT_config] [-v | --verbose] [-a | --aws] --config CONFIG_FILE [--date DATE]
+  COMMAND_NAME [--cyhy-config CYHY_CONFIG] [--scan-config SCAN_CONFIG] [--assessment-config ASSESSMENT_CONFIG] [-v | --verbose] [-a | --aws] --config CONFIG_FILE [--date DATE]
   COMMAND_NAME (-h | --help)
   COMMAND_NAME --version
 
 Options:
   -h --help                                                         Show this screen
   --version                                                         Show version
-  -x CYHY_CONFIG --cyhy_config=CYHY_CONFIG                       CyHy configuration section to use
-  -y SCAN_CONFIG --scan_config=SCAN_CONFIG                       Scan configuration section to use
-  -z ASSESSMENT_CONFIG --assessment_config=ASSESSMENT_CONFIG     Assessment configuration section to use
+  -x CYHY_CONFIG --cyhy-config=CYHY_CONFIG                       CyHy configuration section to use
+  -y SCAN_CONFIG --scan-config=SCAN_CONFIG                       Scan configuration section to use
+  -z ASSESSMENT_CONFIG --assessment-config=ASSESSMENT_CONFIG     Assessment configuration section to use
   -v --verbose                                                      Show verbose output
   -a --aws                                                          Output results to s3 bucket
   -c CONFIG_FILE --config=CONFIG_FILE                               Configuration file for this script

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Usage:
 Options:
   -h --help                                                         Show this screen
   --version                                                         Show version
-  -x CYHY_CONFIG --cyhy-config=CYHY_CONFIG                       CyHy configuration section to use
-  -y SCAN_CONFIG --scan-config=SCAN_CONFIG                       Scan configuration section to use
-  -z ASSESSMENT_CONFIG --assessment-config=ASSESSMENT_CONFIG     Assessment configuration section to use
+  -x CYHY_CONFIG --cyhy-config=CYHY_CONFIG                          CyHy configuration section to use
+  -y SCAN_CONFIG --scan-config=SCAN_CONFIG                          Scan configuration section to use
+  -z ASSESSMENT_CONFIG --assessment-config=ASSESSMENT_CONFIG        Assessment configuration section to use
   -v --verbose                                                      Show verbose output
   -a --aws                                                          Output results to s3 bucket
   -c CONFIG_FILE --config=CONFIG_FILE                               Configuration file for this script

--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -27,7 +27,6 @@ from ConfigParser import SafeConfigParser
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from docopt import docopt
-import dateutil.tz as tz
 import boto3
 import gnupg    # pip install python-gnupg
 import os
@@ -35,10 +34,8 @@ from pytz import timezone
 import subprocess
 import tarfile
 import time
-import json
-import bson
-import netaddr
-from mongo_db_from_config import db_from_config
+from cyhy.db import database
+from cyhy.util import util
 from dmarc import get_dmarc_data
 
 BUCKET_NAME = 'ncats-moe-data'
@@ -50,29 +47,8 @@ DAYS_OF_DMARC_REPORTS = 1
 PAGE_SIZE = 100000  # Number of documents per query
 
 
-def custom_json_handler(obj):
-    """Format the provided JSON object in the desired """
-    if hasattr(obj, 'isoformat'):
-        return obj.isoformat()
-    elif type(obj) == bson.objectid.ObjectId:
-        return repr(obj)
-    elif type(obj) == netaddr.IPAddress:
-        return str(obj)
-    elif type(obj) == netaddr.IPNetwork:
-        return str(obj)
-    elif type(obj) == netaddr.IPSet:
-        return obj.iter_cidrs()
-    else:
-        raise TypeError('Object of type %s with value of %s is not JSON serializable' % (type(obj), repr(obj)))
-
-
-def to_json(obj):
-    """Return a string version of the formatted JSON."""
-    return json.dumps(obj, sort_keys=True, indent=4, default=custom_json_handler)
-
-
 def update_bucket(bucket_name, local_file, remote_file_name):
-    """update the s3 bucket with the new contents"""
+    '''update the s3 bucket with the new contents'''
 
     s3 = boto3.client('s3')
 
@@ -80,7 +56,7 @@ def update_bucket(bucket_name, local_file, remote_file_name):
 
 
 def create_dummy_files(output_dir):
-    """ Used for testing cleanup routine below """
+    ''' Used for testing cleanup routine below '''
     for n in range(1, 21):
         dummy_filename = 'dummy_file_{!s}.gpg'.format(n)
         full_path_dummy_filename = os.path.join(output_dir, dummy_filename)
@@ -93,8 +69,8 @@ def create_dummy_files(output_dir):
 
 
 def cleanup_old_files(output_dir, file_retention_num_days):
-    """Deletes *.gpg files older than file_retention_num_days in the
-specified output_dir"""
+    '''Deletes *.gpg files older than file_retention_num_days in the
+specified output_dir'''
     now_unix = time.time()
     for filename in os.listdir(output_dir):
         # We only care about filenames that end with .gpg
@@ -118,7 +94,7 @@ def cleanup_bucket_files(aws_access_key_id, aws_secret_access_key):
         aws_secret_access_key=aws_secret_access_key
     )
 
-    if len(s3.list_objects(Bucket=BUCKET_NAME)['Contents']) > MAX_ENTRIES:
+    if(len(s3.list_objects(Bucket=BUCKET_NAME)['Contents']) > MAX_ENTRIES):
         for key in s3.list_objects(Bucket=BUCKET_NAME)['Contents']:
             print(key)
             print(key['LastModified'])
@@ -136,7 +112,7 @@ def query_data(collection, query, tbz_file, tbz_filename,
     count = collection.find(query, {'key': False}).count()
     while skips < count:
         # Pull documents between n and n + 100000
-        collection_file.write(to_json(list(collection.find(query, {'key': False}).skip(skips).limit(PAGE_SIZE))))
+        collection_file.write(util.to_json(list(collection.find(query, {'key': False}).skip(skips).limit(PAGE_SIZE))))
         skips += PAGE_SIZE
     collection_file.close()
     if count > PAGE_SIZE:
@@ -164,12 +140,12 @@ def main():
     __doc__ = re.sub('COMMAND_NAME', __file__, __doc__)
     args = docopt(__doc__, version='v0.0.1')
     if args['--cyhy_section']:
-        cyhy_db = db_from_config(args['--cyhy_section'])
+        cyhy_db = database.db_from_config(args['--cyhy_section'])
     if args['--scan_section']:
-        scan_db = db_from_config(args['--scan_section'])
+        scan_db = database.db_from_config(args['--scan_section'])
     if args['--assessment_section']:
-        assessment_db = db_from_config(args['--assessment_section'])
-    now = datetime.now(tz.tzutc())
+        assessment_db = database.db_from_config(args['--assessment_section'])
+    now = util.utcnow()
     # import IPython; IPython.embed() #<<< BREAKPOINT >>>
     # sys.exit(0)
 
@@ -324,7 +300,7 @@ def main():
                        tbz_file, tbz_filename, end_of_data_collection)
 
     # Note that we use the elasticsearch AWS profile here
-    json_data = to_json(get_dmarc_data(ES_REGION, ES_URL,
+    json_data = util.to_json(get_dmarc_data(ES_REGION, ES_URL,
                                             DAYS_OF_DMARC_REPORTS,
                                             ES_RETRIEVE_SIZE,
                                             ES_AWS_CONFIG_SECTION_NAME))

--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -325,9 +325,9 @@ def main():
 
     # Note that we use the elasticsearch AWS profile here
     json_data = to_json(get_dmarc_data(ES_REGION, ES_URL,
-                                            DAYS_OF_DMARC_REPORTS,
-                                            ES_RETRIEVE_SIZE,
-                                            ES_AWS_CONFIG_SECTION_NAME))
+                                       DAYS_OF_DMARC_REPORTS,
+                                       ES_RETRIEVE_SIZE,
+                                       ES_AWS_CONFIG_SECTION_NAME))
     json_filename = '{!s}_{!s}.json'.format('DMARC',
                                             end_of_data_collection.isoformat().replace(':', '').split('.')[0])
     dmarc_file = open(json_filename, 'w')

--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -26,7 +26,6 @@ from ConfigParser import SafeConfigParser
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import dateutil.tz as tz
-from docopt import docopt
 import json
 import os
 import subprocess
@@ -35,6 +34,7 @@ import time
 
 import boto3
 import bson
+from docopt import docopt
 import gnupg    # pip install python-gnupg
 from mongo_db_from_config import db_from_config
 import netaddr

--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -27,17 +27,17 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import dateutil.tz as tz
 from docopt import docopt
-import boto3
-import gnupg    # pip install python-gnupg
-import os
 import json
+import os
+import boto3
 import bson
+import gnupg    # pip install python-gnupg
+from mongo_db_from_config import db_from_config
 import netaddr
 from pytz import timezone
 import subprocess
 import tarfile
 import time
-from mongo_db_from_config import db_from_config
 from dmarc import get_dmarc_data
 
 BUCKET_NAME = 'ncats-moe-data'

--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -29,15 +29,17 @@ import dateutil.tz as tz
 from docopt import docopt
 import json
 import os
+import subprocess
+import tarfile
+import time
+
 import boto3
 import bson
 import gnupg    # pip install python-gnupg
 from mongo_db_from_config import db_from_config
 import netaddr
 from pytz import timezone
-import subprocess
-import tarfile
-import time
+
 from dmarc import get_dmarc_data
 
 BUCKET_NAME = 'ncats-moe-data'
@@ -218,11 +220,7 @@ def main():
         end_of_data_collection = start_of_data_collection + relativedelta(days=1)
 
     # Get a list of all non-retired orgs
-    org_filter = {
-            '_id': {'$ne': 'ROOT'},
-            'retired': {'$ne': True}
-    }
-    all_orgs = cyhy_db['requests'].find(org_filter, {'_id': 1}).distinct('_id')
+    all_orgs = cyhy_db['requests'].find({'retired': {'$ne': True}}, {'_id': 1}).distinct('_id')
     orgs = list(set(all_orgs) - ORGS_EXCLUDED)
 
     # Create tar/bzip2 file for writing

--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -33,7 +33,6 @@ import os
 import json
 import bson
 import netaddr
-import pymongo
 from pytz import timezone
 import subprocess
 import tarfile

--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -10,9 +10,9 @@ Usage:
 Options:
   -h --help                                                         Show this screen
   --version                                                         Show version
-  -x CYHY_CONFIG --cyhy_config=CYHY_CONFIG                          CyHy MongoDB configuration to use
-  -y SCAN_CONFIG --scan_config=SCAN_CONFIG                          Scan MongoDB configuration to use
-  -z ASSESSMENT_CONFIG --assessment_config=ASSESSMENT_CONFIG        Assessment MongoDB configuration to use
+  -x CYHY_CONFIG --cyhy-config=CYHY_CONFIG                          CyHy MongoDB configuration to use
+  -y SCAN_CONFIG --scan-config=SCAN_CONFIG                          Scan MongoDB configuration to use
+  -z ASSESSMENT_CONFIG --assessment-config=ASSESSMENT_CONFIG        Assessment MongoDB configuration to use
   -v --verbose                                                      Show verbose output
   -a --aws                                                          Output results to s3 bucket
   -c CONFIG_FILE --config=CONFIG_FILE                               Configuration file for this script

--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -3,7 +3,7 @@
 data for integration with the Weathermap project.
 
 Usage:
-  COMMAND_NAME [--cyhy_config CYHY_CONFIG] [--scan_config SCAN_CONFIG] [--assessment_config ASSESSMENT_CONFIG] [-v | --verbose] [-a | --aws] --config CONFIG_FILE [--date DATE]
+  COMMAND_NAME [--cyhy-config CYHY_CONFIG] [--scan-config SCAN_CONFIG] [--assessment-config ASSESSMENT_CONFIG] [-v | --verbose] [-a | --aws] --config CONFIG_FILE [--date DATE]
   COMMAND_NAME (-h | --help)
   COMMAND_NAME --version
 
@@ -163,12 +163,12 @@ def main():
     global __doc__
     __doc__ = re.sub('COMMAND_NAME', __file__, __doc__)
     args = docopt(__doc__, version='v0.0.1')
-    if args['--cyhy_section']:
-        cyhy_db = db_from_config(args['--cyhy_section'])
-    if args['--scan_section']:
-        scan_db = db_from_config(args['--scan_section'])
-    if args['--assessment_section']:
-        assessment_db = db_from_config(args['--assessment_section'])
+    if args['--cyhy-config']:
+        cyhy_db = db_from_config(args['--cyhy-config'])
+    if args['--scan-config']:
+        scan_db = db_from_config(args['--scan-config'])
+    if args['--assessment-config']:
+        assessment_db = db_from_config(args['--assessment-config'])
     now = datetime.now(tz.tzutc())
     # import IPython; IPython.embed() #<<< BREAKPOINT >>>
     # sys.exit(0)
@@ -223,10 +223,7 @@ def main():
             '_id': {'$ne': 'ROOT'},
             'retired': {'$ne': True}
     }
-    all_orgs = []
-    results = cyhy_db['requests'].find(org_filter, {'_id': 1})
-    for doc in results:
-        all_orgs.append(doc['_id'])
+    all_orgs = cyhy_db['requests'].find(org_filter, {'_id': 1}).distinct('_id')
     orgs = list(set(all_orgs) - ORGS_EXCLUDED)
 
     # Create tar/bzip2 file for writing
@@ -313,15 +310,15 @@ def main():
         'findings': {}
     }
 
-    if args['--cyhy_section']:
+    if args['--cyhy-config']:
         for collection in cyhy_collection:
             query_data(cyhy_db[collection], cyhy_collection[collection],
                        tbz_file, tbz_filename, end_of_data_collection)
-    if args['--scan_section']:
+    if args['--scan-config']:
         for collection in scan_collection:
             query_data(scan_db[collection], scan_collection[collection],
                        tbz_file, tbz_filename, end_of_data_collection)
-    if args['--assessment_section']:
+    if args['--assessment-config']:
         for collection in assessment_collection:
             query_data(assessment_db[collection],
                        assessment_collection[collection],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 --index-url https://pypi.python.org/simple/
--e https://github.com/cisagov/mongo-db-from-config.git
+
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 --index-url https://pypi.python.org/simple/
--e https://github.com/cisagov/mongo-db-from-config.git
+-e git://github.com/cisagov/mongo-db-from-config.git
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 --index-url https://pypi.python.org/simple/
-
+-e https://github.com/cisagov/mongo-db-from-config.git
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 --index-url https://pypi.python.org/simple/
--e git://github.com/cisagov/mongo-db-from-config.git
+-e https://github.com/cisagov/mongo-db-from-config.git
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
---index-url https://pypi.python.org/simple/
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 --index-url https://pypi.python.org/simple/
-
+https://api.github.com/repos/cisagov/mongo-db-from-config/tarball/develop
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 --index-url https://pypi.python.org/simple/
-https://api.github.com/repos/cisagov/mongo-db-from-config/tarball/develop
 -e .

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,14 @@ setup(
     description='Data feed components for Cyber Hygiene',
     #long_description=open('README.txt').read(),
     install_requires=[
+        "boto3 >= 1.8.7",
+        "docopt >= 0.6.2",
+        "mongo-db-from-config >= 0.0.1",
+        "netaddr >= 0.7.10",
         "pymongo >= 2.9.2, < 3",
         "python-dateutil >= 2.2",
-        "netaddr >= 0.7.10",
-        "docopt >= 0.6.2",
-        "boto3 >= 1.8.7",
         "python-gnupg >= 0.4.3",
         "requests >= 2.18.4",
-        "requests-aws4auth >= 0.9",
-        "mongo-db-from-config >= 0.0.1"
+        "requests-aws4auth >= 0.9"        
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -3,19 +3,21 @@ from distutils.core import setup
 setup(
     name='cyhy-feeds',
     version='0.0.2',
-    author='Department of Homeland Security, National Cybersecurity Assessments and Technical Services team',
-    author_email='ncats@hq.dhs.gov',
-    packages=[], #TODO
-    scripts=[], #TODO
-    #url='http://pypi.python.org/pypi/CyHy/',
-    license='LICENSE.txt',
-    description='Data feed components for Cyber Hygiene',
-    #long_description=open('README.txt').read(),
+    author="Cyber and Infrastructure Security Agency",
+    author_email="ncats@hq.dhs.gov",
+    packages=[],  # TODO
+    scripts=[],  # TODO
+    # NCATS "homepage"
+    url="https://www.us-cert.gov/resources/ncats",
+    license="License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
+    description="Data feed components for Cyber Hygiene",
+    # long_description=open('README.txt').read(),
     install_requires=[
-        "cyhy-core >= 0.0.2",
+        "pymongo >= 2.9.2, < 3",
         "python-dateutil >= 2.2",
+        "netaddr >= 0.7.10",
         "docopt >= 0.6.2",
-	"boto3 >= 1.8.7",
+        "boto3 >= 1.8.7",
         "python-gnupg >= 0.4.3",
         "requests >= 2.18.4",
         "requests-aws4auth >= 0.9"

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "boto3 >= 1.8.7",
         "python-gnupg >= 0.4.3",
         "requests >= 2.18.4",
-        "requests-aws4auth >= 0.9"
+        "requests-aws4auth >= 0.9",
+        "mongo-db-from-config >= 0.0.1"
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -3,21 +3,19 @@ from distutils.core import setup
 setup(
     name='cyhy-feeds',
     version='0.0.2',
-    author="Cyber and Infrastructure Security Agency",
-    author_email="ncats@hq.dhs.gov",
-    packages=[],  # TODO
-    scripts=[],  # TODO
-    # NCATS "homepage"
-    url="https://www.us-cert.gov/resources/ncats",
-    license="License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
-    description="Data feed components for Cyber Hygiene",
-    # long_description=open('README.txt').read(),
+    author='Department of Homeland Security, National Cybersecurity Assessments and Technical Services team',
+    author_email='ncats@hq.dhs.gov',
+    packages=[], #TODO
+    scripts=[], #TODO
+    #url='http://pypi.python.org/pypi/CyHy/',
+    license='LICENSE.txt',
+    description='Data feed components for Cyber Hygiene',
+    #long_description=open('README.txt').read(),
     install_requires=[
-        "pymongo >= 2.9.2, < 3",
+        "cyhy-core >= 0.0.2",
         "python-dateutil >= 2.2",
-        "netaddr >= 0.7.10",
         "docopt >= 0.6.2",
-        "boto3 >= 1.8.7",
+	"boto3 >= 1.8.7",
         "python-gnupg >= 0.4.3",
         "requests >= 2.18.4",
         "requests-aws4auth >= 0.9"

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,11 @@ setup(
     description='Data feed components for Cyber Hygiene',
     #long_description=open('README.txt').read(),
     install_requires=[
-        "cyhy-core >= 0.0.2",
+        "pymongo >= 2.9.2, < 3",
         "python-dateutil >= 2.2",
+        "netaddr >= 0.7.10",
         "docopt >= 0.6.2",
-	"boto3 >= 1.8.7",
+        "boto3 >= 1.8.7",
         "python-gnupg >= 0.4.3",
         "requests >= 2.18.4",
         "requests-aws4auth >= 0.9"


### PR DESCRIPTION
This PR is oriented on removing the current requirement for the private cyhy-core repo from cyhy-feeds per #17 . The two utility functions used in cyhy-core were migrated into cyhy-feeds and MongoDB connections are made using [mongo-db-from-config](https://github.com/cisagov/mongo-db-from-config) instead. Command line arguments were changed to reflect using individual yml files for database configurations (per mongo-db-from-config functionality) instead of sections of the configuration file.