### PR TITLE
Check that the Errors key is in the response from the delete_objects(…

### DIFF
--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -138,12 +138,13 @@ def cleanup_bucket_files(object_retention_days):
                 ]
             },
         )
-        for err in del_resp["Errors"]:
-            sys.stderr.write(
-                "Error: {} when deleting {} - {}\n".format(
-                    err["Message"], err["Key"], err["Code"]
+        if "Errors" in del_resp:
+            for err in del_resp["Errors"]:
+                sys.stderr.write(
+                    "Error: {} when deleting {} - {}\n".format(
+                        err["Message"], err["Key"], err["Code"]
+                    )
                 )
-            )
         if response["IsTruncated"] is not True:
             break
 

--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -138,13 +138,12 @@ def cleanup_bucket_files(object_retention_days):
                 ]
             },
         )
-        if "Errors" in del_resp:
-            for err in del_resp["Errors"]:
-                sys.stderr.write(
-                    "Error: {} when deleting {} - {}\n".format(
-                        err["Message"], err["Key"], err["Code"]
-                    )
+        for err in del_resp.get("Errors", []):
+            sys.stderr.write(
+                "Error: {} when deleting {} - {}\n".format(
+                    err["Message"], err["Key"], err["Code"]
                 )
+            )
         if response["IsTruncated"] is not True:
             break
 


### PR DESCRIPTION
This is to check for the existence of the key "Errors" in the response from the delete_objects request in cleanup_bucket_files(). The documentation does not list it as an optional element, but if there are no errors a KeyError exception is thrown when the script attempts to iterate over the "Errors" key.