### PR TITLE
Fix setup open for py2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,36 +38,22 @@ Create compressed, encrypted, signed extract file with Federal CyHy data for
 integration with the Weathermap project.
 
 Usage:
-  COMMAND_NAME [--cyhy-config CYHY_CONFIG] [--scan-config SCAN_CONFIG]
-    [--assessment-config ASSESSMENT_CONFIG] [-v | --verbose] [-a | --aws]
-    --config CONFIG_FILE [--date DATE]
+  COMMAND_NAME --config CONFIG_FILE [--cyhy-config CYHY_CONFIG] [--scan-config SCAN_CONFIG] [--assessment-config ASSESSMENT_CONFIG] [-v | --verbose] [-a | --aws ] [--cleanup-aws] [--date DATE] [--debug]
   COMMAND_NAME (-h | --help)
   COMMAND_NAME --version
 
 Options:
-  -h --help                                                       Show this screen
-  --version                                                       Show version
-  -x CYHY_CONFIG --cyhy-config=CYHY_CONFIG                        CyHy configuration
-                                                                  file to use
-  -y SCAN_CONFIG --scan-config=SCAN_CONFIG                        Scan configuration
-                                                                  file to use
-  -z ASSESSMENT_CONFIG --assessment-config=ASSESSMENT_CONFIG      Assessment configuration
-                                                                  file to use
-  -v --verbose                                                    Show verbose output
-  -a --aws                                                        Output results
-                                                                  to S3 bucket
-  --cleanup-aws                                                   Delete old files
-                                                                  from the S3 bucket
-  -c CONFIG_FILE --config=CONFIG_FILE                             Configuration file
-                                                                  for this script
-  -d DATE --date=DATE                                             Specific date to
-                                                                  export data from
-                                                                  in form:
-                                                                  %YYYY-%MM-%DD
-                                                                  (eg. 2018-12-31)
-                                                                  NOTE that this
-                                                                  date is in UTC
-
+  -h --help                                                         Show this screen
+  --version                                                         Show version
+  -x CYHY_CONFIG --cyhy-config=CYHY_CONFIG                          CyHy MongoDB configuration to use
+  -y SCAN_CONFIG --scan-config=SCAN_CONFIG                          Scan MongoDB configuration to use
+  -z ASSESSMENT_CONFIG --assessment-config=ASSESSMENT_CONFIG        Assessment MongoDB configuration to use
+  -v --verbose                                                      Show verbose output
+  -a --aws                                                          Output results to S3 bucket
+  --cleanup-aws                                                     Delete old files from the S3 bucket
+  -c CONFIG_FILE --config=CONFIG_FILE                               Configuration file for this script
+  -d DATE --date=DATE                                               Specific date to export data from in form: %Y-%m-%d (eg. 2018-12-31) NOTE that this date is in UTC
+  --debug                                                           Enable debug logging
 ```
 
 #### cyhy-data-extract Examples ####

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     keywords="cyhy",
     packages=find_packages(where="aws_jobs"),
     package_dir={"": "aws_jobs"},
-    package_data={"example": ["data/*.txt"]},
+    package_data={},
     py_modules=[splitext(basename(path))[0] for path in glob("aws_jobs/*.py")],
     include_package_data=True,
     install_requires=[
@@ -74,7 +74,7 @@ setup(
         "docopt >= 0.6.2",
         "mongo-db-from-config @ https://github.com/cisagov/mongo-db-from-config/tarball/develop#egg=mongo-db-from-config",
         "netaddr >= 0.7.10",
-        "python-dateutil >= 2.2",
+        "python-dateutil >= 2.2, < 2.8.1",
         "python-gnupg >= 0.4.3",
         "pytz",
         "requests >= 2.18.4",

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,9 @@ setup(
         "docopt >= 0.6.2",
         "mongo-db-from-config @ https://github.com/cisagov/mongo-db-from-config/tarball/develop#egg=mongo-db-from-config",
         "netaddr >= 0.7.10",
+        # Due to an installer issue botocore at present requires dateutil < 2.8.1
+        # Please see https://github.com/boto/botocore/issues/1872 for more
+        # information.
         "python-dateutil >= 2.2, < 2.8.1",
         "python-gnupg >= 0.4.3",
         "pytz",

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,19 @@ Based on:
 from setuptools import setup, find_packages
 from glob import glob
 from os.path import splitext, basename
+import io
 
 
 def readme():
     """Read in and return the contents of the project's README.md file."""
-    with open("README.md", encoding="utf-8") as f:
-        return f.read()
+    # Python 3
+    try:
+        with open("README.md", encoding="utf-8") as f:
+            return f.read()
+    # Python 2 fallback
+    except TypeError:
+        with io.open("README.md") as f:
+            return f.read()
 
 
 def package_vars(version_file):

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,10 @@ Based on:
 - https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure
 """
 
-from setuptools import setup, find_packages
 from glob import glob
-from os.path import splitext, basename
 import io
+from os.path import splitext, basename
+from setuptools import setup, find_packages
 
 
 def readme():

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def readme():
             return f.read()
     # Python 2 fallback
     except TypeError:
-        with io.open("README.md") as f:
+        with io.open("README.md", encoding="utf-8") as f:
             return f.read()
 
 


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR fixes an issue where after updating upstream changes the `readme()` function in `setup.py` used a Python 3 only form. This adds in a Python 2 compatible fallback since this script sees primary use in a Python 2 environment at present.

The `py-dateutil` package was also version bounded because of an issue with botocore as seen in https://github.com/boto/botocore/issues/1872
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
The script failed to install requirements because of Python 3 only code used in the `readme()` function which hindered successful AMI building.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I test that `pip install -r requirements.txt` worked correctly in both Python 2 (2.7.16) and Python 3 (3.8.0) environments.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
