### PR TITLE
Enforce that all scripts use Python 3 rather than Python 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
           COVERALLS_PARALLEL: true
           COVERALLS_SERVICE_NAME: github
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ success() }}
+        if: success()
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,28 +21,24 @@ jobs:
         uses: cisagov/setup-env-github-action@develop
       - uses: actions/checkout@v3
       - id: setup-python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       # We need the Go version and Go cache location for the actions/cache step,
       # so the Go installation must happen before that.
-      - uses: actions/setup-go@v2
+      - id: setup-go
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.16"
-      - name: Store installed Go version
-        id: go-version
-        run: |
-          echo "::set-output name=version::"\
-          "$(go version | sed 's/^go version go\([0-9.]\+\) .*/\1/')"
+          go-version: "1.19"
       - name: Lookup Go cache directory
         id: go-cache
         run: |
-          echo "::set-output name=dir::$(go env GOCACHE)"
+          echo "dir=$(go env GOCACHE)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         env:
           BASE_CACHE_KEY: "${{ github.job }}-${{ runner.os }}-\
             py${{ steps.setup-python.outputs.python-version }}-\
-            go${{ steps.go-version.outputs.version }}-\
+            go${{ steps.setup-go.outputs.go-version }}-\
             packer${{ steps.setup-env.outputs.packer-version }}-\
             tf${{ steps.setup-env.outputs.terraform-version }}-"
         with:
@@ -82,7 +78,7 @@ jobs:
             ${{ env.CURL_CACHE_DIR }}/"${PACKER_ZIP}"
           sudo mv /usr/local/bin/packer /usr/local/bin/packer-default
           sudo ln -s /opt/packer/packer /usr/local/bin/packer
-      - uses: hashicorp/setup-terraform@v1
+      - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ steps.setup-env.outputs.terraform-version }}
       - name: Install shfmt
@@ -97,7 +93,7 @@ jobs:
         run: go install ${PACKAGE_URL}@${PACKAGE_VERSION}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools wheel
           pip install --upgrade --requirement requirements-test.txt
       - name: Set up pre-commit hook environments
         run: pre-commit install-hooks
@@ -107,20 +103,26 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
   test:
-    runs-on: ubuntu-latest
+    name: test source - py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-latest
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
+        include:
+          - os: ubuntu-20.04
+            python-version: "3.6"
     steps:
       - uses: actions/checkout@v3
       - id: setup-python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v3
@@ -159,11 +161,12 @@ jobs:
         if: env.RUN_TMATE
   coveralls-finish:
     runs-on: ubuntu-latest
-    needs: test
+    needs:
+      - test
     steps:
       - uses: actions/checkout@v3
       - id: setup-python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - uses: actions/cache@v3
@@ -193,21 +196,29 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
   build:
-    runs-on: ubuntu-latest
-    needs: [lint, test]
+    name: build wheel - py${{ matrix.python-version }}
+    needs:
+      - lint
+      - test
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-latest
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
+        include:
+          - os: ubuntu-20.04
+            python-version: "3.6"
     steps:
       - uses: actions/checkout@v3
       - id: setup-python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v3
@@ -224,17 +235,75 @@ jobs:
             ${{ hashFiles('setup.py') }}"
           restore-keys: |
             ${{ env.BASE_CACHE_KEY }}
-      - name: Install dependencies
+      - name: Install build dependencies
         run: |
-          python -m pip install --upgrade pip wheel
-          pip install --upgrade --requirement requirements.txt
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade build
       - name: Build artifacts
-        run: python3 setup.py sdist bdist_wheel
+        run: python -m build
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dist-${{ matrix.python-version }}
           path: dist
+      - name: Setup tmate debug session
+        uses: mxschmitt/action-tmate@v3
+        if: env.RUN_TMATE
+  test-build:
+    name: test built wheel - py${{ matrix.python-version }}
+    needs:
+      - build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+        include:
+          - os: ubuntu-20.04
+            python-version: "3.6"
+    steps:
+      - uses: actions/checkout@v3
+      - id: setup-python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v3
+        env:
+          BASE_CACHE_KEY: "${{ github.job }}-${{ runner.os }}-\
+            py${{ steps.setup-python.outputs.python-version }}-"
+        with:
+          path: ${{ env.PIP_CACHE_DIR }}
+          # We do not use '**/setup.py' in the cache key so only the 'setup.py'
+          # file in the root of the repository is used. This is in case a Python
+          # package were to have a 'setup.py' as part of its internal codebase.
+          key: "${{ env.BASE_CACHE_KEY }}\
+            ${{ hashFiles('**/requirements.txt') }}-\
+            ${{ hashFiles('setup.py') }}"
+          restore-keys: |
+            ${{ env.BASE_CACHE_KEY }}
+      - name: Retrieve the built wheel
+        uses: actions/download-artifact@v3
+        with:
+          name: dist-${{ matrix.python-version }}
+          path: dist
+      - id: find-wheel
+        name: Get the name of the retrieved wheel (there should only be one)
+        run: echo "wheel=$(ls dist/*whl)" >> $GITHUB_OUTPUT
+      - name: Update core Python packages
+        run: python -m pip install --upgrade pip setuptools wheel
+      - name: Install the built wheel (along with testing dependencies)
+        run: python -m pip install ${{ steps.find-wheel.outputs.wheel }}[test]
+      - name: Run tests
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: pytest
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "2.7"
           - "3.6"
           - "3.7"
           - "3.8"
@@ -154,9 +153,7 @@ jobs:
           COVERALLS_PARALLEL: true
           COVERALLS_SERVICE_NAME: github
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Skip this step for Python 2.7 because coveralls uploads
-        # are no longer supported
-        if: ${{ (matrix.python-version != '2.7') && success() }}
+        if: ${{ success() }}
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
@@ -202,7 +199,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "2.7"
           - "3.6"
           - "3.7"
           - "3.8"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: check-case-conflict
       - id: check-executables-have-shebangs
@@ -31,17 +31,17 @@ repos:
 
   # Text file hooks
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.31.1
+    rev: v0.33.0
     hooks:
       - id: markdownlint
         args:
           - --config=.mdl_config.yaml
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.1
+    rev: v3.0.0-alpha.6
     hooks:
       - id: prettier
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.26.3
+    rev: v1.30.0
     hooks:
       - id: yamllint
         args:
@@ -49,14 +49,14 @@ repos:
 
   # GitHub Actions hooks
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.14.2
+    rev: 0.22.0
     hooks:
       - id: check-github-actions
       - id: check-github-workflows
 
   # pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit
-    rev: v2.17.0
+    rev: v3.2.1
     hooks:
       - id: validate_manifest
 
@@ -81,28 +81,47 @@ repos:
       - id: shell-lint
 
   # Python hooks
+  # Run bandit on the "tests" tree with a configuration
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.5
+    hooks:
+      - id: bandit
+        name: bandit (tests tree)
+        files: tests
+        args:
+          - --config=.bandit.yml
+  # Run bandit on everything except the "tests" tree
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.4
     hooks:
       - id: bandit
-        args:
-          - --config=.bandit.yml
+        name: bandit (everything else)
+        exclude: tests
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.1.1
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - types-python-dateutil
+          - types-pytz
+          - types-requests
+          - types-setuptools
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
 
@@ -115,14 +134,14 @@ repos:
 
   # Terraform hooks
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.64.0
+    rev: v1.77.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
 
   # Docker hooks
   - repo: https://github.com/IamTheFij/docker-pre-commit
-    rev: v2.1.0
+    rev: v2.1.1
     hooks:
       - id: docker-compose-check
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,7 @@ decrypt it, and then decompress it to local storage.
 
 ## Getting Started ##
 
-`cyhy-data-extract` requires **Python 2** because it has not been updated
-to remove all Python 2 requirements. Python 3 is not officially supported
-at this time.
-
-`cyhy-data-retriever` can run as either Python 2 or Python 3.
+Both `cyhy-data-extract` and `cyhy-data-retriever` require Python 3.
 
 To run the tool locally first install the requirements:
 
@@ -62,21 +58,21 @@ Extract CyHy data for the current day using the MongoDB configuration in `cyhy.y
 and the runtime configuration in `cyhy-data-extract.cfg`.
 
 ```console
-python2.7 cyhy-data-extract.py --cyhy-config cyhy.yml --config cyhy-data-extract.cfg
+python3 cyhy-data-extract.py --cyhy-config cyhy.yml --config cyhy-data-extract.cfg
 ```
 
 Extract scan data for the current day using the MongoDB configuration in 'scan.yml'
 and the runtime configuration in `cyhy-data-extract.cfg`.
 
 ```console
-python2.7 cyhy-data-extract.py --scan-config scan.yml --config cyhy-data-extract.cfg
+python3 cyhy-data-extract.py --scan-config scan.yml --config cyhy-data-extract.cfg
 ```
 
 Extract assessment data for the current day using the MongoDB configuration in
 `assessment.yml` and the runtime configuration in `cyhy-data-extract.cfg`.
 
 ```console
-python2.7 cyhy-data-extract.py --assessment-config assessment.yml --config cyhy-data-extract.cfg
+python3 cyhy-data-extract.py --assessment-config assessment.yml --config cyhy-data-extract.cfg
 ```
 
 Extract CyHy and scan data for the current day using the MongoDB configurations
@@ -84,7 +80,7 @@ in `cyhy.yml` and `scan.yml`, respectively, and use the runtime configuration in
 `cyhy-data-extract.cfg`.
 
 ```console
-python2.7 cyhy-data-extract.py --cyhy-config cyhy.yml --scan-config scan.yml
+python3 cyhy-data-extract.py --cyhy-config cyhy.yml --scan-config scan.yml
   --config cyhy-data-extract.cfg
 ```
 
@@ -93,7 +89,7 @@ in `cyhy.yml` and `scan.yml`, upload the results to AWS, and use the runtime
 configuration in `cyhy-data-extract.cfg`.
 
 ```console
-python2.7 cyhy-data-extract.py --cyhy-config cyhy.yml --scan-config scan.yml
+python3 cyhy-data-extract.py --cyhy-config cyhy.yml --scan-config scan.yml
   --aws --config cyhy-data-extract.cfg
 ```
 
@@ -102,7 +98,7 @@ in `cyhy.yml` and `scan.yml`, upload the results to AWS, and use the runtime
 configuration in `cyhy-data-extract.cfg`.
 
 ```console
-python2.7 cyhy-data-extract.py --cyhy-config cyhy.yml --scan-config scan.yml
+python3 cyhy-data-extract.py --cyhy-config cyhy.yml --scan-config scan.yml
   --aws --config cyhy-data-extract.cfg --date 2019-01-25
 ```
 
@@ -111,7 +107,7 @@ configurations in `cyhy.yml`, `scan.yml`, and `assessment.yml`, upload the resul
 to AWS, and use the runtime configuration in `cyhy-data-extract.cfg`.
 
 ```console
-python2.7 cyhy-data-extract.py --cyhy-config cyhy.yml --scan-config scan.yml
+python3 cyhy-data-extract.py --cyhy-config cyhy.yml --scan-config scan.yml
   --assessment-config assessment.yml --aws --config cyhy-data-extract.cfg
   --date 2019-01-25
 ```

--- a/aws_jobs/_version.py
+++ b/aws_jobs/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.0.4"
+__version__ = "0.0.5"

--- a/aws_jobs/_version.py
+++ b/aws_jobs/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "0.0.5"
+__version__ = "0.0.5-rc.1"

--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Create compressed, encrypted, signed extract file with Federal CyHy data for integration with the Weathermap project.
 
 Usage:

--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -22,7 +22,7 @@ Options:
 """
 
 # Standard Python Libraries
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 from datetime import datetime
 import json
 import logging
@@ -266,7 +266,7 @@ def main():
     now = datetime.now(tz.tzutc())
 
     # Read parameters in from config file
-    config = SafeConfigParser()
+    config = ConfigParser()
     config.read([args["--config"]])
     ORGS_EXCLUDED = set(config.get("DEFAULT", "FED_ORGS_EXCLUDED").split(","))
     if ORGS_EXCLUDED == {""}:

--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -240,7 +240,7 @@ def main():
     """Retrieve data, aggreate into a compressed archive, and encrypt it to store or upload to S3."""
     global __doc__
     __doc__ = __doc__.replace("COMMAND_NAME", __file__)
-    args = docopt(__doc__, version="v0.0.1")
+    args = docopt(__doc__, version="0.0.5-rc.1")
 
     setup_logging(args["--debug"])
 

--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -216,14 +216,16 @@ def query_data(collection, cursor, tbz_file, tbz_filename, end_of_data_collectio
     with open(json_filename, "w") as collection_file:
         collection_file.write("[")
 
+        file_position = collection_file.tell()
         for doc in cursor:
             collection_file.write(to_json([doc])[1:-2])
+            file_position = collection_file.tell()
             collection_file.write(",")
 
         if cursor.retrieved != 0:
             # If we output documents then we have a trailing comma, so we need to
-            # roll back the file location by one byte to overwrite as we finish
-            collection_file.seek(-1, os.SEEK_END)
+            # roll back the file location to before the comma to overwrite as we finish
+            collection_file.seek(file_position)
 
         collection_file.write("\n]")
 

--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -22,6 +22,7 @@ Options:
 """
 
 # Standard Python Libraries
+from configparser import SafeConfigParser
 from datetime import datetime
 import json
 import logging
@@ -44,14 +45,6 @@ from pytz import timezone
 # cisagov Libraries
 from dmarc import get_dmarc_data
 from mongo_db_from_config import db_from_config
-
-# Import the appropriate version of SafeConfigParser.
-if sys.version_info.major == 2:
-    # Standard Python Libraries
-    from ConfigParser import SafeConfigParser
-else:
-    # Standard Python Libraries
-    from configparser import SafeConfigParser
 
 # Logging core variables
 logger = logging.getLogger("cyhy-feeds")

--- a/aws_jobs/cyhy-data-retriever.py
+++ b/aws_jobs/cyhy-data-retriever.py
@@ -21,6 +21,7 @@ Options:
 """
 
 # Standard Python Libraries
+from configparser import SafeConfigParser
 from datetime import datetime
 import re
 import sys
@@ -33,15 +34,6 @@ from dateutil.relativedelta import relativedelta
 import dateutil.tz as tz
 from docopt import docopt
 import gnupg
-
-# Import the appropriate version of SafeConfigParser.
-if sys.version_info.major == 2:
-    # Standard Python Libraries
-    from ConfigParser import SafeConfigParser
-else:
-    # Standard Python Libraries
-    from configparser import SafeConfigParser
-
 
 BUCKET_NAME = "ncats-moe-data"
 DOMAIN = "ncats-moe-data"

--- a/aws_jobs/cyhy-data-retriever.py
+++ b/aws_jobs/cyhy-data-retriever.py
@@ -21,7 +21,7 @@ Options:
 """
 
 # Standard Python Libraries
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 from datetime import datetime
 import re
 import sys
@@ -47,7 +47,7 @@ def main():
     now = datetime.now(tz.tzutc())
 
     # Read parameters in from config file
-    config = SafeConfigParser()
+    config = ConfigParser()
     config.read([args["--config"]])
     GNUPG_HOME = config.get("DEFAULT", "GNUPG_HOME")
     GPG_DECRYPTION_PASSPHRASE = config.get("DEFAULT", "GPG_DECRYPTION_PASSPHRASE")

--- a/aws_jobs/cyhy-data-retriever.py
+++ b/aws_jobs/cyhy-data-retriever.py
@@ -67,7 +67,6 @@ def main():
 
     # Download extract file from s3
     if args["--aws"]:
-
         s3 = boto3.client(
             "s3",
             aws_access_key_id=AWS_ACCESS_KEY_ID,

--- a/aws_jobs/cyhy-data-retriever.py
+++ b/aws_jobs/cyhy-data-retriever.py
@@ -43,7 +43,7 @@ def main():
     """Process a provided file to decrypt and extract the contents of a cyhy-data-extract run."""
     global __doc__
     __doc__ = re.sub("COMMAND_NAME", __file__, __doc__)
-    args = docopt(__doc__, version="v0.0.1")
+    args = docopt(__doc__, version="0.0.5-rc.1")
     now = datetime.now(tz.tzutc())
 
     # Read parameters in from config file

--- a/setup.py
+++ b/setup.py
@@ -74,11 +74,14 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: Implementation :: CPython",
     ],
     python_requires=">=3.6",
     # What does your project relate to?

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 """
-This is the setup module for cyhy-feeds.
+This is the setup module for the cyhy-feeds project.
 
 Based on:
 
@@ -9,9 +9,9 @@ Based on:
 """
 
 # Standard Python Libraries
+import codecs
 from glob import glob
-import io
-from os.path import basename, splitext
+from os.path import abspath, basename, dirname, join, splitext
 
 # Third-Party Libraries
 from setuptools import find_packages, setup
@@ -19,35 +19,48 @@ from setuptools import find_packages, setup
 
 def readme():
     """Read in and return the contents of the project's README.md file."""
-    # Python 3
-    try:
-        with open("README.md", encoding="utf-8") as f:
-            return f.read()
-    # Python 2 fallback
-    except TypeError:
-        with io.open("README.md", encoding="utf-8") as f:
-            return f.read()
+    with open("README.md", encoding="utf-8") as f:
+        return f.read()
 
 
-def package_vars(version_file):
-    """Read in and return the variables defined by the version_file."""
-    pkg_vars = {}
-    with open(version_file) as f:
-        exec(f.read(), pkg_vars)  # nosec
-    return pkg_vars
+# Below two methods were pulled from:
+# https://packaging.python.org/guides/single-sourcing-package-version/
+def read(rel_path):
+    """Open a file for reading from a given relative path."""
+    here = abspath(dirname(__file__))
+    with codecs.open(join(here, rel_path), "r") as fp:
+        return fp.read()
+
+
+def get_version(version_file):
+    """Extract a version number from the given file path."""
+    for line in read(version_file).splitlines():
+        if line.startswith("__version__"):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    raise RuntimeError("Unable to find version string.")
 
 
 setup(
     name="cyhy-feeds",
-    version=package_vars("aws_jobs/_version.py")["__version__"],
-    author="Cyber and Infrastructure Security Agency",
-    author_email="ncats@hq.dhs.gov",
-    url="https://www.us-cert.gov/resources/ncats",
-    download_url="https://github.com/cisagov/cyhy-feeds",
-    license="License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
+    # Versions should comply with PEP440
+    version=get_version("aws_jobs/_version.py"),
     description="Data feed components for Cyber Hygiene",
     long_description=readme(),
     long_description_content_type="text/markdown",
+    # Landing page for CISA's cybersecurity mission
+    url="https://www.cisa.gov/cybersecurity",
+    # Additional URLs for this project per
+    # https://packaging.python.org/guides/distributing-packages-using-setuptools/#project-urls
+    project_urls={
+        "Source": "https://github.com/cisagov/skeleton-python-library",
+        "Tracker": "https://github.com/cisagov/skeleton-python-library/issues",
+    },
+    # Author details
+    author="Cybersecurity and Infrastructure Security Agency",
+    author_email="github@cisa.dhs.gov",
+    license="License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         # How mature is this project? Common values are
         #   3 - Alpha
@@ -60,13 +73,14 @@ setup(
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
+    python_requires=">=3.6",
     # What does your project relate to?
     keywords="cyhy",
     packages=find_packages(where="aws_jobs"),
@@ -84,6 +98,7 @@ setup(
         "pytz",
         "requests >= 2.18.4",
         "requests-aws4auth >= 0.9",
+        "setuptools >= 24.2.0",
     ],
     extras_require={
         "test": [

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,8 @@ setup(
     # Additional URLs for this project per
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#project-urls
     project_urls={
-        "Source": "https://github.com/cisagov/skeleton-python-library",
-        "Tracker": "https://github.com/cisagov/skeleton-python-library/issues",
+        "Source": "https://github.com/cisagov/cyhy-feeds",
+        "Tracker": "https://github.com/cisagov/cyhy-feeds/issues",
     },
     # Author details
     author="Cybersecurity and Infrastructure Security Agency",


### PR DESCRIPTION
## 🗣 Description ##

This pull request makes a change to enforce that all the scripts contained in this repo use Python 3 vice Python 2.

## 💭 Motivation and context ##

The one remaining script that used Python 2 code appears to work with either Python 2 or Python 3, so it makes sense to insist on Python 3 now that Python 2 is EOL.

## 🧪 Testing ##

All automated tests pass.

@mcdonnnj, is this one line change something that can be manually done in production to verify that it functions as expected?

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Create a release.
