### PR TITLE
Include `period_start` in request doc output

### DIFF
--- a/aws_jobs/cyhy-data-extract.py
+++ b/aws_jobs/cyhy-data-extract.py
@@ -389,6 +389,7 @@ def main():
                 "agency.type": True,
                 "children": True,
                 "networks": True,
+                "period_start": True,
                 "report_types": True,
                 "retired": True,
                 "scan_types": True,


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the `period_start` field into the request document output.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This field was requested; resolves https://github.com/cisagov/cyhy-system/issues/69.

It's important to remember that `period_start` indicates the most-recent start time of scanning for an organization.  It may be the initial start of scanning, but if an organization has ever paused and resumed their scanning, `period_start` will show the time when scanning was most-recently resumed, not when it was initially started.  Also, while scanning is paused for an organization, `period_start` will be set to a date far in the future (the year 9999).

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I manually made this change in a test environment and ran `cyhy-data-extract.py`.  I confirmed that the `period_start` field was indeed included in the requests JSON file as intended.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Coordinate with downstream stakeholders on Production deployment date.
- [x] Deploy updated code to Production.
