### PR TITLE
Use ansible-lint v25.4.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -185,7 +185,7 @@ repos:
 
   # Ansible hooks
   - repo: https://github.com/ansible/ansible-lint
-    rev: v25.1.3
+    rev: v25.4.0
     hooks:
       - id: ansible-lint
         additional_dependencies:


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR upgrades the version of ansible-lint used by pre-commit from v25.1.3 to v25.4.0 (which is the version [currently used in cisagov/skeleton-generic right now](https://github.com/cisagov/skeleton-generic/blob/d2d823664a1562774e80f3ba34b1005d5acddd76/.pre-commit-config.yaml#L168)).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When pre-commit ran ansible-lint v25.1.3, it was [failing with an error like this](https://github.com/cisagov/cyhy-feeds/actions/runs/17590948715/job/49972317678#step:20:64):
```
Ansible-lint.............................................................Failed
- hook id: ansible-lint
- exit code: 1

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/runner/.cache/pre-commit/repowhkiifr3/py_env-python3/lib/python3.13/site-packages/ansiblelint/__main__.py", line 50, in <module>
    from ansiblelint import cli
  File "/home/runner/.cache/pre-commit/repowhkiifr3/py_env-python3/lib/python3.13/site-packages/ansiblelint/cli.py", line 30, in <module>
    from ansiblelint.yaml_utils import clean_json
  File "/home/runner/.cache/pre-commit/repowhkiifr3/py_env-python3/lib/python3.13/site-packages/ansiblelint/yaml_utils.py", line 33, in <module>
    from ansiblelint.utils import Task
  File "/home/runner/.cache/pre-commit/repowhkiifr3/py_env-python3/lib/python3.13/site-packages/ansiblelint/utils.py", line 49, in <module>
    from ansible.parsing.yaml.constructor import AnsibleConstructor, AnsibleMapping
ModuleNotFoundError: No module named 'ansible.parsing.yaml.constructor'
```

Upgrading to the newer version appears to have fixed the issue.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I confirmed that pre-commit is now [passing in GitHub Actions with v25.4.0 of ansible-lint](https://github.com/cisagov/cyhy-feeds/actions/runs/17592764383/job/49977464294#step:20:64).

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

