### PR TITLE
Make the `mypy` `pre-commit` hook ignore `setup.py`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -166,6 +166,9 @@ repos:
           - types-pytz
           - types-requests
           - types-setuptools
+        # We get some goofy mypy errors about mismatched types with
+        # extras_require and project_urls, so just skip this file.
+        exclude: setup.py
   - repo: https://github.com/pypa/pip-audit
     rev: v2.8.0
     hooks:


### PR DESCRIPTION
## 🗣 Description ##

This pull request makes the `mypy` `pre-commit` hook ignore `setup.py`.

## 💭 Motivation and context ##

We get some goofy and unhelpful `mypy` errors about mismatched types with the `extras_require` and `project_urls` arguments to `setup()`, so it makes sense to just skip this file.

THese `mypy` errors are causing the [APB builds to fail](https://github.com/cisagov/cyhy-feeds/actions/runs/21272840027).

## 🧪 Testing ##

All automated tests pass.  The `lint` check was failing without this change.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.